### PR TITLE
Fix incorrect handling of static imports.

### DIFF
--- a/src/main/java/org/onlab/jdvue/Catalog.java
+++ b/src/main/java/org/onlab/jdvue/Catalog.java
@@ -93,12 +93,18 @@ public class Catalog {
 
             } else if (pragma[0].equals(IMPORT)) {
                 if (pragma[1].equals(STATIC)) {
-                    processImportStatement(source, pragma[2]);
+                    processImportStatement(source, sansMethodName(pragma[2]));
                 } else {
                     processImportStatement(source, pragma[1]);
                 }
             }
         }
+    }
+
+    // assumes s is a dot-delimited string: "some.package.ClassName.methodName"
+    private String sansMethodName(String s) {
+        int ri = s.lastIndexOf(".");
+        return ri >= 0 ? s.substring(0, ri) : s;
     }
 
     // strips off trailing "/xxxxxxxxxx.java" if there is one

--- a/src/test/java/org/onlab/jdvue/CatalogTest.java
+++ b/src/test/java/org/onlab/jdvue/CatalogTest.java
@@ -74,4 +74,37 @@ public class CatalogTest {
         assertEquals("incorrect segment count", 3, cat.getCycleSegments().size());
         assertEquals("incorrect cycle count", 1, cat.getCycles().size());
     }
+
+    @Test
+    public void abcCatNormal() throws IOException {
+        Catalog cat = new Catalog();
+        cat.load("src/test/resources/abc_cat_normal.db");
+        cat.analyze();
+
+        assertEquals("incorrect package count", 4, cat.getPackages().size());
+        assertEquals("incorrect source count", 4, cat.getSources().size());
+
+        assertEquals("incorrect segment count", 3, cat.getCycleSegments().size());
+        assertEquals("incorrect cycle count", 1, cat.getCycles().size());
+    }
+
+    @Test
+    public void abcCatStatic() throws IOException {
+        /*
+            Verify that static imports are correctly parsed to return the "source" name (not the "method" name)...
+
+            src/com/foobar/loop/alpha/Aaa.java:package com.foobar.loop.alpha;
+            src/com/foobar/loop/alpha/Aaa.java:import static com.foobar.loop.beta.Bbb.returnCodeB;
+                                               ^^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^
+         */
+        Catalog cat = new Catalog();
+        cat.load("src/test/resources/abc_cat_static.db");
+        cat.analyze();
+
+        assertEquals("incorrect package count", 4, cat.getPackages().size());
+        assertEquals("incorrect source count", 4, cat.getSources().size());
+
+        assertEquals("incorrect segment count", 3, cat.getCycleSegments().size());
+        assertEquals("incorrect cycle count", 1, cat.getCycles().size());
+    }
 }

--- a/src/test/resources/abc_cat_normal.db
+++ b/src/test/resources/abc_cat_normal.db
@@ -1,0 +1,10 @@
+src/com/foobar/loop/Main.java:package com.foobar.loop;
+src/com/foobar/loop/Main.java:import com.foobar.loop.alpha.Aaa;
+src/com/foobar/loop/Main.java:import com.foobar.loop.beta.Bbb;
+src/com/foobar/loop/Main.java:import com.foobar.loop.gamma.Ccc;
+src/com/foobar/loop/alpha/Aaa.java:package com.foobar.loop.alpha;
+src/com/foobar/loop/alpha/Aaa.java:import com.foobar.loop.gamma.Ccc;
+src/com/foobar/loop/beta/Bbb.java:package com.foobar.loop.beta;
+src/com/foobar/loop/beta/Bbb.java:import com.foobar.loop.alpha.Aaa;
+src/com/foobar/loop/gamma/Ccc.java:package com.foobar.loop.gamma;
+src/com/foobar/loop/gamma/Ccc.java:import com.foobar.loop.beta.Bbb;

--- a/src/test/resources/abc_cat_static.db
+++ b/src/test/resources/abc_cat_static.db
@@ -1,0 +1,10 @@
+src/com/foobar/loop/Main.java:package com.foobar.loop;
+src/com/foobar/loop/Main.java:import com.foobar.loop.alpha.Aaa;
+src/com/foobar/loop/Main.java:import com.foobar.loop.beta.Bbb;
+src/com/foobar/loop/Main.java:import com.foobar.loop.gamma.Ccc;
+src/com/foobar/loop/alpha/Aaa.java:package com.foobar.loop.alpha;
+src/com/foobar/loop/alpha/Aaa.java:import static com.foobar.loop.beta.Bbb.returnCodeB;
+src/com/foobar/loop/beta/Bbb.java:package com.foobar.loop.beta;
+src/com/foobar/loop/beta/Bbb.java:import static com.foobar.loop.gamma.Ccc.returnCodeC;
+src/com/foobar/loop/gamma/Ccc.java:package com.foobar.loop.gamma;
+src/com/foobar/loop/gamma/Ccc.java:import static com.foobar.loop.alpha.Aaa.returnCodeA;

--- a/src/test/resources/non_maven_cat.db
+++ b/src/test/resources/non_maven_cat.db
@@ -23,6 +23,5 @@
 ./PyTest/foobardir/nonstandard/test/unit/src/com/foobar/view/BeanViewerTest.java:package com.foobar.view;
 ./PyTest/foobardir/nonstandard/test/unit/src/com/foobar/view/BeanViewerTest.java:import java.util.List;
 ./PyTest/foobardir/nonstandard/test/unit/src/com/foobar/view/BeanViewerTest.java:import junit.framework.TestCase;
-./PyTest/foobardir/nonstandard/test/unit/src/com/foobar/view/BeanViewerTest.java:import static com.foobar.util.MathUtils.neato;
 ./PyTest/foobardir/nonstandard/test/unit/src/com/foobar/view/BeanViewerTest.java:import com.foobar.model.MagicBean;
 ./PyTest/foobardir/nonstandard/test/unit/src/com/foobar/view/BeanViewerTest.java:import com.foobar.model.PlantPot;


### PR DESCRIPTION
The _Catalog_ was not correctly inferring the _Source_ entity from `static import` lines.

The fix was to strip the method name from the end of the static import target.